### PR TITLE
refactor: Simplify UpdateApplication mechanism, get rid of the SKIP func

### DIFF
--- a/internal/app/updater/commit.go
+++ b/internal/app/updater/commit.go
@@ -37,7 +37,6 @@ func commitChangesLocked(cfg HelmUpdaterConfig, state *SyncIterationState) (*[]C
 // after the UpdateApplication cycle has finished.
 func commitChangesGit(cfg HelmUpdaterConfig, write changeWriter) (*[]ChangeEntry, error) {
 	var apps []ChangeEntry
-	var skip bool
 	var gitCommitMessage string
 
 	logCtx := log.WithContext().AddField("application", cfg.AppName)
@@ -97,11 +96,8 @@ func commitChangesGit(cfg HelmUpdaterConfig, write changeWriter) (*[]ChangeEntry
 	}
 
 	// write changes to files
-	if err, skip, apps = write(cfg, gitC); err != nil {
+	if apps, err = write(cfg, gitC); err != nil {
 		return nil, err
-		//TODO: Review how to do when skip
-	} else if skip {
-		return nil, nil
 	}
 
 	commitOpts := &git.CommitOptions{}


### PR DESCRIPTION
In general, this small refactor is about getting rid of returning 3 params including the `skip` boolean value.

I have realized that if we're returning an empty list of ChangeEntry - that means there are no changes, and it's equivalent of the `skip` functionality.

![image](https://user-images.githubusercontent.com/17459288/149952150-682c173a-8ddf-4f51-8b0e-771c3e042fd5.png)