### PR TITLE
fix: add arm64 to goreleaser

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -12,6 +12,7 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
 
 changelog:
   sort: desc


### PR DESCRIPTION
This will generate the binaries with `arm64` architecture in the release process using [goreleaser](https://goreleaser.com/)