### PR TITLE
feat: add option for allow error message `nothing to update, skipping commit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   - [Installation](#installation)
   - [Usage](#usage)
   - [Examples of usage](#examples-of-usage)
+    - [Using the binary](#using-the-binary)
+    - [Using a Docker Container](#using-a-docker-container)
   - [Running the tests](#running-the-tests)
     - [Tests requirements](#tests-requirements)
     - [Launch tests](#launch-tests)
@@ -59,177 +61,179 @@ This repo aims to manage the development of `helm-repo-updater`, a CLI tool whos
 
 ## Examples of usage
 
-- Using the binary directly from the machine:
-  - Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `test-repo` repository:
-    ```bash
-    $ helm-repo-updater run \
+### Using the binary
+
+- Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `test-repo` repository:
+  ```bash
+  $ helm-repo-updater run \
+    --app-name=example-app \
+    --git-branch="develop" \
+    --git-commit-user="test-user" \
+    --git-commit-email="test-user@docplanner.com" \
+    --git-file="values.yaml" \
+    --helm-key-values=".image.tag=1.1.0" \
+    --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
+    --ssh-private-key="test-git-server/private_keys/helm-repo-updater-test"
+  INFO[2022-03-03T16:23:10+01:00] Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /var/folders/vb/v4wr_9f52ns4mmdkwp4_35cm0000gp/T/git-example-app956297090  application=example-app
+  Enumerating objects: 4, done.
+  Counting objects: 100% (4/4), done.
+  Total 4 (delta 0), reused 0 (delta 0), pack-reused 0
+  INFO[2022-03-03T16:23:11+01:00] Pulling latest changes of branch develop      application=example-app
+  INFO[2022-03-03T16:23:11+01:00] Actual value for key .image.tag: 1.0.0        application=example-app
+  INFO[2022-03-03T16:23:11+01:00] Setting new value for key .image.tag: 1.1.0   application=example-app
+  INFO[2022-03-03T16:23:11+01:00] Adding file example-app/values.yaml to git for commit changes  application=example-app
+  INFO[2022-03-03T16:23:11+01:00] It's going to commit changes with message: 🚀 automatic update of example-app
+  updates key .image.tag value from '1.0.0' to '1.1.0'  application=example-app
+  INFO[2022-03-03T16:23:11+01:00] It's going to push commit with hash ca9ce40520f018094a2cd7952847e7ea4bb949fe and message 🚀 automatic update of example-app
+  updates key .image.tag value from '1.0.0' to '1.1.0'  application=example-app
+  INFO[2022-03-03T16:23:11+01:00] Pushing changes                               application=example-app
+  INFO[2022-03-03T16:23:11+01:00] Successfully pushed changes                   application=example-app
+  INFO[2022-03-03T16:23:11+01:00] Successfully updated the live application spec  application=example-app
+  ```
+
+- Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `test-repo` repository, being `1.1.0` the value currently present in the repository for the above key:
+  ```
+  $ helm-repo-updater run \
+    --app-name=example-app \
+    --git-branch="develop" \
+    --git-commit-user="test-user" \
+    --git-commit-email="test-user@docplanner.com" \
+    --git-file="values.yaml" \
+    --helm-key-values=".image.tag=1.1.0" \
+    --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
+    --ssh-private-key="test-git-server/private_keys/helm-repo-updater-test"
+  INFO[2022-03-03T16:24:17+01:00] Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /var/folders/vb/v4wr_9f52ns4mmdkwp4_35cm0000gp/T/git-example-app1208822616  application=example-app
+  Enumerating objects: 8, done.
+  Counting objects: 100% (8/8), done.
+  Compressing objects: 100% (2/2), done.
+  Total 8 (delta 0), reused 0 (delta 0), pack-reused 0
+  INFO[2022-03-03T16:24:17+01:00] Pulling latest changes of branch develop      application=example-app
+  INFO[2022-03-03T16:24:17+01:00] Actual value for key .image.tag: 1.1.0        application=example-app
+  INFO[2022-03-03T16:24:17+01:00] Setting new value for key .image.tag: 1.1.0   application=example-app
+  INFO[2022-03-03T16:24:17+01:00] target for key .image.tag is the same, skipping  application=example-app
+  ERRO[2022-03-03T16:24:17+01:00] Could not update application spec: nothing to update, skipping commit  application=example-app
+  INFO[2022-03-03T16:24:17+01:00] nothing to update, skipping commit  application=example-app
+  ```
+
+  - Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `test-repo` repository, being `1.1.0` the value currently present in the repository for the above key without allowing the error with message `nothing to update, skipping commit`:
+  ```
+  $ helm-repo-updater run \
+    --allow-nothing-to-update=false \
+    --app-name=example-app \
+    --git-branch="develop" \
+    --git-commit-user="test-user" \
+    --git-commit-email="test-user@docplanner.com" \
+    --git-file="values.yaml" \
+    --helm-key-values=".image.tag=1.1.0" \
+    --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
+    --ssh-private-key="test-git-server/private_keys/helm-repo-updater-test"
+  INFO[2022-03-03T16:24:17+01:00] Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /var/folders/vb/v4wr_9f52ns4mmdkwp4_35cm0000gp/T/git-example-app1208822616  application=example-app
+  Enumerating objects: 8, done.
+  Counting objects: 100% (8/8), done.
+  Compressing objects: 100% (2/2), done.
+  Total 8 (delta 0), reused 0 (delta 0), pack-reused 0
+  INFO[2022-03-03T16:24:17+01:00] Pulling latest changes of branch develop      application=example-app
+  INFO[2022-03-03T16:24:17+01:00] Actual value for key .image.tag: 1.1.0        application=example-app
+  INFO[2022-03-03T16:24:17+01:00] Setting new value for key .image.tag: 1.1.0   application=example-app
+  INFO[2022-03-03T16:24:17+01:00] target for key .image.tag is the same, skipping  application=example-app
+  ERRO[2022-03-03T16:24:17+01:00] Could not update application spec: nothing to update, skipping commit  application=example-app
+    ```
+
+### Using a Docker Container
+
+- Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `k8s-argocd-apps` repository for the application `example-app`:
+  ```bash
+  $ docker run -v ~/.ssh/repositories_keys/example-user_github:/tmp/ssh_key ghcr.io/docplanner/helm-repo-updater run \
       --app-name=example-app \
       --git-branch="develop" \
       --git-commit-user="test-user" \
       --git-commit-email="test-user@docplanner.com" \
-      --git-file="values.yaml" \
+      --git-dir="apps/" \
+      --git-file="helm/t0/testing/image.yaml" \
       --helm-key-values=".image.tag=1.1.0" \
       --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
-      --ssh-private-key="test-git-server/private_keys/helm-repo-updater-test"
-    INFO[2022-03-03T16:23:10+01:00] Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /var/folders/vb/v4wr_9f52ns4mmdkwp4_35cm0000gp/T/git-example-app956297090  application=example-app
-    Enumerating objects: 4, done.
-    Counting objects: 100% (4/4), done.
-    Total 4 (delta 0), reused 0 (delta 0), pack-reused 0
-    INFO[2022-03-03T16:23:11+01:00] Pulling latest changes of branch develop      application=example-app
-    INFO[2022-03-03T16:23:11+01:00] Actual value for key .image.tag: 1.0.0        application=example-app
-    INFO[2022-03-03T16:23:11+01:00] Setting new value for key .image.tag: 1.1.0   application=example-app
-    INFO[2022-03-03T16:23:11+01:00] Adding file example-app/values.yaml to git for commit changes  application=example-app
-    INFO[2022-03-03T16:23:11+01:00] It's going to commit changes with message: 🚀 automatic update of example-app
-    updates key .image.tag value from '1.0.0' to '1.1.0'  application=example-app
-    INFO[2022-03-03T16:23:11+01:00] It's going to push commit with hash ca9ce40520f018094a2cd7952847e7ea4bb949fe and message 🚀 automatic update of example-app
-    updates key .image.tag value from '1.0.0' to '1.1.0'  application=example-app
-    INFO[2022-03-03T16:23:11+01:00] Pushing changes                               application=example-app
-    INFO[2022-03-03T16:23:11+01:00] Successfully pushed changes                   application=example-app
-    INFO[2022-03-03T16:23:11+01:00] Successfully updated the live application spec  application=example-app
-    ```
+      --logLevel=debug \
+      --ssh-private-key="/tmp/ssh_key"
+  time="2022-03-04T11:29:07Z" level=debug msg="Successfully parsed commit message template" application=example-app
+  time="2022-03-04T11:29:07Z" level=debug msg="Processing application example-app in directory apps/example-app/helm/t0/testing/image.yaml"
+  time="2022-03-04T11:29:07Z" level=debug msg="Created temporal directory /tmp/git-example-app3237525166 to clone repository git@github.com:DocPlanner/example-repo.git" application=example-app
+  time="2022-03-04T11:29:07Z" level=info msg="Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /tmp/git-example-app3237525166" application=example-app
+  Enumerating objects: 192, done.
+  Counting objects: 100% (183/183), done.
+  Compressing objects: 100% (99/99), done.
+  Total 192 (delta 35), reused 153 (delta 25), pack-reused 9
+  time="2022-03-04T11:29:09Z" level=info msg="Pulling latest changes of branch develop" application=example-app
+  time="2022-03-04T11:29:10Z" level=info msg="Actual value for key .image.tag: 1.0.0" application=example-app
+  time="2022-03-04T11:29:10Z" level=info msg="Setting new value for key .image.tag: 1.1.0" application=example-app
+  time="2022-03-04T11:29:10Z" level=debug msg="templated commit message successfully with value: 🚀 automatic update of example-app\nupdates key .image.tag value from '1.0.0' to '1.1.0'\n" application=example-app
+  time="2022-03-04T11:29:10Z" level=info msg="Adding file apps/example-app/helm/t0/testing/image.yaml to git for commit changes" application=example-app
+  time="2022-03-04T11:29:10Z" level=debug msg="Obtaining current status after changes" application=example-app
+  time="2022-03-04T11:29:10Z" level=debug msg="Obtained git status status is: M  apps/example-app/helm/t0/testing/image.yaml\n" application=example-app
+  time="2022-03-04T11:29:10Z" level=info msg="It's going to commit changes with message: 🚀 automatic update of example-app\nupdates key .image.tag value from '1.0.0' to '1.1.0'\n" application=example-app
+  time="2022-03-04T11:29:10Z" level=debug msg="Obtaining current HEAD to verify added changes" application=example-app
+  time="2022-03-04T11:29:10Z" level=info msg="It's going to push commit with hash cb89e6e2a9a238cd0d1d5cdf29cf408185545ed6 and message 🚀 automatic update of example-app\nupdates key .image.tag value from '1.0.0' to '1.1.0'\n" application=example-app
+  time="2022-03-04T11:29:10Z" level=info msg="Pushing changes" application=example-app
+  time="2022-03-04T11:29:12Z" level=info msg="Successfully pushed changes" application=example-app
+  time="2022-03-04T11:29:12Z" level=info msg="Successfully updated the live application spec" application=example-app
+  ```
 
-  - Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `test-repo` repository, being `1.1.0` the value currently present in the repository for the above key:
-    ```
-    $ helm-repo-updater run \
+- Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `k8s-argocd-apps` repository for the `example-app`, being `1.1.0` the value currently present in the repository for the above key:
+  ```
+  $ docker run -v ~/.ssh/repositories_keys/example-user_github:/tmp/ssh_key ghcr.io/docplanner/helm-repo-updater run \
       --app-name=example-app \
       --git-branch="develop" \
       --git-commit-user="test-user" \
       --git-commit-email="test-user@docplanner.com" \
-      --git-file="values.yaml" \
+      --git-dir="apps/" \
+      --git-file="helm/t0/testing/image.yaml" \
       --helm-key-values=".image.tag=1.1.0" \
       --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
-      --ssh-private-key="test-git-server/private_keys/helm-repo-updater-test"
-    INFO[2022-03-03T16:24:17+01:00] Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /var/folders/vb/v4wr_9f52ns4mmdkwp4_35cm0000gp/T/git-example-app1208822616  application=example-app
-    Enumerating objects: 8, done.
-    Counting objects: 100% (8/8), done.
-    Compressing objects: 100% (2/2), done.
-    Total 8 (delta 0), reused 0 (delta 0), pack-reused 0
-    INFO[2022-03-03T16:24:17+01:00] Pulling latest changes of branch develop      application=example-app
-    INFO[2022-03-03T16:24:17+01:00] Actual value for key .image.tag: 1.1.0        application=example-app
-    INFO[2022-03-03T16:24:17+01:00] Setting new value for key .image.tag: 1.1.0   application=example-app
-    INFO[2022-03-03T16:24:17+01:00] target for key .image.tag is the same, skipping  application=example-app
-    ERRO[2022-03-03T16:24:17+01:00] Could not update application spec: nothing to update, skipping commit  application=example-app
-    INFO[2022-03-03T16:24:17+01:00] nothing to update, skipping commit  application=example-app
-    ```
+      --logLevel=debug \
+      --ssh-private-key="/tmp/ssh_key"
+  time="2022-03-04T11:30:48Z" level=debug msg="Successfully parsed commit message template" application=example-app
+  time="2022-03-04T11:30:48Z" level=debug msg="Processing application example-app in directory apps/example-app/helm/t0/testing/image.yaml"
+  time="2022-03-04T11:30:48Z" level=debug msg="Created temporal directory /tmp/git-example-app2386521755 to clone repository git@github.com:DocPlanner/example-repo.git" application=example-app
+  time="2022-03-04T11:30:48Z" level=info msg="Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /tmp/git-example-app2386521755" application=example-app
+  Enumerating objects: 200, done.
+  Counting objects: 100% (191/191), done.
+  Compressing objects: 100% (103/103), done.
+  Total 200 (delta 37), reused 159 (delta 25), pack-reused 9
+  time="2022-03-04T11:30:49Z" level=info msg="Pulling latest changes of branch develop" application=example-app
+  time="2022-03-04T11:30:50Z" level=info msg="Actual value for key .image.tag: 1.1.0" application=example-app
+  time="2022-03-04T11:30:50Z" level=info msg="Setting new value for key .image.tag: 1.1.0" application=example-app
+  time="2022-03-04T11:30:50Z" level=info msg="target for key .image.tag is the same, skipping" application=example-app
+  time="2022-03-04T11:30:50Z" level=error msg="Could not update application spec: nothing to update, skipping commit" application=example-app
+  time="2022-03-04T11:30:50Z" level=info msg="nothing to update, skipping commit"  application=example-app
+  ```
 
-   - Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `test-repo` repository, being `1.1.0` the value currently present in the repository for the above key without allowing the error with message `nothing to update, skipping commit`:
-    ```
-    $ helm-repo-updater run \
-      --allow-nothing-to-update=false \
+  - Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `k8s-argocd-apps` repository for the `example-app`, being `1.1.0` the value currently present in the repository for the above key without allowing the error with message `nothing to update, skipping commit`::
+  ```
+  $ docker run -v ~/.ssh/repositories_keys/example-user_github:/tmp/ssh_key ghcr.io/docplanner/helm-repo-updater run \
       --app-name=example-app \
       --git-branch="develop" \
       --git-commit-user="test-user" \
       --git-commit-email="test-user@docplanner.com" \
-      --git-file="values.yaml" \
+      --git-dir="apps/" \
+      --git-file="helm/t0/testing/image.yaml" \
       --helm-key-values=".image.tag=1.1.0" \
       --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
-      --ssh-private-key="test-git-server/private_keys/helm-repo-updater-test"
-    INFO[2022-03-03T16:24:17+01:00] Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /var/folders/vb/v4wr_9f52ns4mmdkwp4_35cm0000gp/T/git-example-app1208822616  application=example-app
-    Enumerating objects: 8, done.
-    Counting objects: 100% (8/8), done.
-    Compressing objects: 100% (2/2), done.
-    Total 8 (delta 0), reused 0 (delta 0), pack-reused 0
-    INFO[2022-03-03T16:24:17+01:00] Pulling latest changes of branch develop      application=example-app
-    INFO[2022-03-03T16:24:17+01:00] Actual value for key .image.tag: 1.1.0        application=example-app
-    INFO[2022-03-03T16:24:17+01:00] Setting new value for key .image.tag: 1.1.0   application=example-app
-    INFO[2022-03-03T16:24:17+01:00] target for key .image.tag is the same, skipping  application=example-app
-    ERRO[2022-03-03T16:24:17+01:00] Could not update application spec: nothing to update, skipping commit  application=example-app
-    ```
-
-- Using a Docker Container:
-  - Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `k8s-argocd-apps` repository for the application `example-app`:
-    ```bash
-    $ docker run -v ~/.ssh/repositories_keys/example-user_github:/tmp/ssh_key ghcr.io/docplanner/helm-repo-updater run \
-        --app-name=example-app \
-        --git-branch="develop" \
-        --git-commit-user="test-user" \
-        --git-commit-email="test-user@docplanner.com" \
-        --git-dir="apps/" \
-        --git-file="helm/t0/testing/image.yaml" \
-        --helm-key-values=".image.tag=1.1.0" \
-        --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
-        --logLevel=debug \
-        --ssh-private-key="/tmp/ssh_key"
-    time="2022-03-04T11:29:07Z" level=debug msg="Successfully parsed commit message template" application=example-app
-    time="2022-03-04T11:29:07Z" level=debug msg="Processing application example-app in directory apps/example-app/helm/t0/testing/image.yaml"
-    time="2022-03-04T11:29:07Z" level=debug msg="Created temporal directory /tmp/git-example-app3237525166 to clone repository git@github.com:DocPlanner/example-repo.git" application=example-app
-    time="2022-03-04T11:29:07Z" level=info msg="Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /tmp/git-example-app3237525166" application=example-app
-    Enumerating objects: 192, done.
-    Counting objects: 100% (183/183), done.
-    Compressing objects: 100% (99/99), done.
-    Total 192 (delta 35), reused 153 (delta 25), pack-reused 9
-    time="2022-03-04T11:29:09Z" level=info msg="Pulling latest changes of branch develop" application=example-app
-    time="2022-03-04T11:29:10Z" level=info msg="Actual value for key .image.tag: 1.0.0" application=example-app
-    time="2022-03-04T11:29:10Z" level=info msg="Setting new value for key .image.tag: 1.1.0" application=example-app
-    time="2022-03-04T11:29:10Z" level=debug msg="templated commit message successfully with value: 🚀 automatic update of example-app\nupdates key .image.tag value from '1.0.0' to '1.1.0'\n" application=example-app
-    time="2022-03-04T11:29:10Z" level=info msg="Adding file apps/example-app/helm/t0/testing/image.yaml to git for commit changes" application=example-app
-    time="2022-03-04T11:29:10Z" level=debug msg="Obtaining current status after changes" application=example-app
-    time="2022-03-04T11:29:10Z" level=debug msg="Obtained git status status is: M  apps/example-app/helm/t0/testing/image.yaml\n" application=example-app
-    time="2022-03-04T11:29:10Z" level=info msg="It's going to commit changes with message: 🚀 automatic update of example-app\nupdates key .image.tag value from '1.0.0' to '1.1.0'\n" application=example-app
-    time="2022-03-04T11:29:10Z" level=debug msg="Obtaining current HEAD to verify added changes" application=example-app
-    time="2022-03-04T11:29:10Z" level=info msg="It's going to push commit with hash cb89e6e2a9a238cd0d1d5cdf29cf408185545ed6 and message 🚀 automatic update of example-app\nupdates key .image.tag value from '1.0.0' to '1.1.0'\n" application=example-app
-    time="2022-03-04T11:29:10Z" level=info msg="Pushing changes" application=example-app
-    time="2022-03-04T11:29:12Z" level=info msg="Successfully pushed changes" application=example-app
-    time="2022-03-04T11:29:12Z" level=info msg="Successfully updated the live application spec" application=example-app
-    ```
-
-  - Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `k8s-argocd-apps` repository for the `example-app`, being `1.1.0` the value currently present in the repository for the above key:
-    ```
-    $ docker run -v ~/.ssh/repositories_keys/example-user_github:/tmp/ssh_key ghcr.io/docplanner/helm-repo-updater run \
-        --app-name=example-app \
-        --git-branch="develop" \
-        --git-commit-user="test-user" \
-        --git-commit-email="test-user@docplanner.com" \
-        --git-dir="apps/" \
-        --git-file="helm/t0/testing/image.yaml" \
-        --helm-key-values=".image.tag=1.1.0" \
-        --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
-        --logLevel=debug \
-        --ssh-private-key="/tmp/ssh_key"
-    time="2022-03-04T11:30:48Z" level=debug msg="Successfully parsed commit message template" application=example-app
-    time="2022-03-04T11:30:48Z" level=debug msg="Processing application example-app in directory apps/example-app/helm/t0/testing/image.yaml"
-    time="2022-03-04T11:30:48Z" level=debug msg="Created temporal directory /tmp/git-example-app2386521755 to clone repository git@github.com:DocPlanner/example-repo.git" application=example-app
-    time="2022-03-04T11:30:48Z" level=info msg="Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /tmp/git-example-app2386521755" application=example-app
-    Enumerating objects: 200, done.
-    Counting objects: 100% (191/191), done.
-    Compressing objects: 100% (103/103), done.
-    Total 200 (delta 37), reused 159 (delta 25), pack-reused 9
-    time="2022-03-04T11:30:49Z" level=info msg="Pulling latest changes of branch develop" application=example-app
-    time="2022-03-04T11:30:50Z" level=info msg="Actual value for key .image.tag: 1.1.0" application=example-app
-    time="2022-03-04T11:30:50Z" level=info msg="Setting new value for key .image.tag: 1.1.0" application=example-app
-    time="2022-03-04T11:30:50Z" level=info msg="target for key .image.tag is the same, skipping" application=example-app
-    time="2022-03-04T11:30:50Z" level=error msg="Could not update application spec: nothing to update, skipping commit" application=example-app
-    time="2022-03-04T11:30:50Z" level=info msg="nothing to update, skipping commit"  application=example-app
-    ```
-
-    - Example run to update the `.image.tag` key to `1.1.0` in the `develop` branch of the `k8s-argocd-apps` repository for the `example-app`, being `1.1.0` the value currently present in the repository for the above key without allowing the error with message `nothing to update, skipping commit`::
-    ```
-    $ docker run -v ~/.ssh/repositories_keys/example-user_github:/tmp/ssh_key ghcr.io/docplanner/helm-repo-updater run \
-        --app-name=example-app \
-        --git-branch="develop" \
-        --git-commit-user="test-user" \
-        --git-commit-email="test-user@docplanner.com" \
-        --git-dir="apps/" \
-        --git-file="helm/t0/testing/image.yaml" \
-        --helm-key-values=".image.tag=1.1.0" \
-        --git-repo-url="git@github.com:DocPlanner/example-repo.git" \
-        --logLevel=debug \
-        --ssh-private-key="/tmp/ssh_key"
-    time="2022-03-04T11:30:48Z" level=debug msg="Successfully parsed commit message template" application=example-app
-    time="2022-03-04T11:30:48Z" level=debug msg="Processing application example-app in directory apps/example-app/helm/t0/testing/image.yaml"
-    time="2022-03-04T11:30:48Z" level=debug msg="Created temporal directory /tmp/git-example-app2386521755 to clone repository git@github.com:DocPlanner/example-repo.git" application=example-app
-    time="2022-03-04T11:30:48Z" level=info msg="Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /tmp/git-example-app2386521755" application=example-app
-    Enumerating objects: 200, done.
-    Counting objects: 100% (191/191), done.
-    Compressing objects: 100% (103/103), done.
-    Total 200 (delta 37), reused 159 (delta 25), pack-reused 9
-    time="2022-03-04T11:30:49Z" level=info msg="Pulling latest changes of branch develop" application=example-app
-    time="2022-03-04T11:30:50Z" level=info msg="Actual value for key .image.tag: 1.1.0" application=example-app
-    time="2022-03-04T11:30:50Z" level=info msg="Setting new value for key .image.tag: 1.1.0" application=example-app
-    time="2022-03-04T11:30:50Z" level=info msg="target for key .image.tag is the same, skipping" application=example-app
-    time="2022-03-04T11:30:50Z" level=error msg="Could not update application spec: nothing to update, skipping commit" application=example-app
-    time="2022-03-04T11:30:50Z" level=error msg="Error trying to update the example-app application: nothing to update, skipping commit" application=example-app
-    ```
+      --logLevel=debug \
+      --ssh-private-key="/tmp/ssh_key"
+  time="2022-03-04T11:30:48Z" level=debug msg="Successfully parsed commit message template" application=example-app
+  time="2022-03-04T11:30:48Z" level=debug msg="Processing application example-app in directory apps/example-app/helm/t0/testing/image.yaml"
+  time="2022-03-04T11:30:48Z" level=debug msg="Created temporal directory /tmp/git-example-app2386521755 to clone repository git@github.com:DocPlanner/example-repo.git" application=example-app
+  time="2022-03-04T11:30:48Z" level=info msg="Cloning git repository git@github.com:DocPlanner/example-repo.git in temporal folder located in /tmp/git-example-app2386521755" application=example-app
+  Enumerating objects: 200, done.
+  Counting objects: 100% (191/191), done.
+  Compressing objects: 100% (103/103), done.
+  Total 200 (delta 37), reused 159 (delta 25), pack-reused 9
+  time="2022-03-04T11:30:49Z" level=info msg="Pulling latest changes of branch develop" application=example-app
+  time="2022-03-04T11:30:50Z" level=info msg="Actual value for key .image.tag: 1.1.0" application=example-app
+  time="2022-03-04T11:30:50Z" level=info msg="Setting new value for key .image.tag: 1.1.0" application=example-app
+  time="2022-03-04T11:30:50Z" level=info msg="target for key .image.tag is the same, skipping" application=example-app
+  time="2022-03-04T11:30:50Z" level=error msg="Could not update application spec: nothing to update, skipping commit" application=example-app
+  time="2022-03-04T11:30:50Z" level=error msg="Error trying to update the example-app application: nothing to update, skipping commit" application=example-app
+  ```
 
 ## Running the tests
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,9 +39,47 @@ const (
 	LogLevel = "logLevel"
 	// HelmKeyValues will be used for indicate the key and values to be changed in helm
 	HelmKeyValues = "helm-key-values"
+	// AllowErrorNothingToUpdate represents that is allowed the error nothing to update
+	AllowErrorNothingToUpdate = "allow-nothing-to-update"
+	// AllowErrorNothingToUpdateMessage represents the allowed error that will be the exception for make an os.Exit(1) call when is detected
+	AllowErrorNothingToUpdateMessage = "nothing to update, skipping commit"
 )
 
 var cfg = updater.HelmUpdaterConfig{}
+
+// runImageUpdater checks and apply the necessary update in the helm application
+func runImageUpdater(cfg updater.HelmUpdaterConfig) error {
+
+	syncState := updater.NewSyncIterationState()
+
+	err := func(cfg updater.HelmUpdaterConfig) error {
+		log.Debugf("Processing application %s in directory %s", cfg.AppName, cfg.File)
+
+		_, err := updater.UpdateApplication(cfg, syncState)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}(cfg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// checkExecutionRunImageUpdater represents the check of the execution of the runImageUpdater command
+func checkExecutionRunImageUpdater(cfg updater.HelmUpdaterConfig, logCtx *log.Context, appName string, allowErrorNothingToUpdate bool) {
+	if err := runImageUpdater(cfg); err != nil {
+		if err.Error() != AllowErrorNothingToUpdateMessage || !allowErrorNothingToUpdate {
+			logCtx.Errorf("Error trying to update the %s application: %v", appName, err)
+			os.Exit(1)
+		}
+		logCtx.Infof("%s", err.Error())
+		return
+	}
+}
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
@@ -61,6 +99,7 @@ var runCmd = &cobra.Command{
 		dryRun, _ := cmd.Flags().GetBool(DryRun)
 		useSSHPrivateKeyAsInline, _ := cmd.Flags().GetBool(UseSSHPrivateKeyAsInline)
 		helmKVs, _ := cmd.Flags().GetStringToString(HelmKeyValues)
+		allowErrorNothingToUpdate, _ := cmd.Flags().GetBool(AllowErrorNothingToUpdate)
 
 		if err := log.SetLogLevel(logLevel); err != nil {
 			fmt.Println(err)
@@ -119,32 +158,8 @@ var runCmd = &cobra.Command{
 			GitConf:        gitConf,
 		}
 
-		if err = runImageUpdater(cfg); err != nil {
-			logCtx.Errorf("Error trying to update the %s application: %v", appName, err)
-			os.Exit(1)
-		}
+		checkExecutionRunImageUpdater(cfg, logCtx, appName, allowErrorNothingToUpdate)
 	},
-}
-
-func runImageUpdater(cfg updater.HelmUpdaterConfig) error {
-
-	syncState := updater.NewSyncIterationState()
-
-	err := func(cfg updater.HelmUpdaterConfig) error {
-		log.Debugf("Processing application %s in directory %s", cfg.AppName, cfg.File)
-
-		_, err := updater.UpdateApplication(cfg, syncState)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}(cfg)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func init() {
@@ -163,6 +178,7 @@ func init() {
 	runCmd.Flags().Bool(DryRun, false, "run in dry-run mode. If set to true, do not perform any changes")
 	runCmd.Flags().String(LogLevel, "info", "set the loglevel to one of trace|debug|info|warn|error")
 	runCmd.Flags().StringToString(HelmKeyValues, nil, "helm key-values sets")
+	runCmd.Flags().Bool(AllowErrorNothingToUpdate, true, "allow the error message 'nothing to update, skipping commit' and finish without exit 1 the execution")
 
 	_ = runCmd.MarkFlagRequired(GitCommitUser)
 	_ = runCmd.MarkFlagRequired(GitCommitEmail)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -70,9 +70,9 @@ func runImageUpdater(cfg updater.HelmUpdaterConfig) error {
 }
 
 // checkExecutionRunImageUpdater represents the check of the execution of the runImageUpdater command
-func checkExecutionRunImageUpdater(cfg updater.HelmUpdaterConfig, logCtx *log.Context, appName string, allowErrorNothingToUpdate bool) {
+func checkExecutionRunImageUpdater(cfg updater.HelmUpdaterConfig, logCtx *log.Context, appName string) {
 	if err := runImageUpdater(cfg); err != nil {
-		if err.Error() != AllowErrorNothingToUpdateMessage || !allowErrorNothingToUpdate {
+		if err.Error() != AllowErrorNothingToUpdateMessage || !cfg.AllowErrorNothingToUpdate {
 			logCtx.Errorf("Error trying to update the %s application: %v", appName, err)
 			os.Exit(1)
 		}
@@ -149,16 +149,17 @@ var runCmd = &cobra.Command{
 		gitConf.Message = tpl
 
 		cfg = updater.HelmUpdaterConfig{
-			DryRun:         dryRun,
-			LogLevel:       logLevel,
-			AppName:        appName,
-			UpdateApps:     updateApps,
-			File:           path.Join(gitDir, appName, gitFile),
-			GitCredentials: gitCredentials,
-			GitConf:        gitConf,
+			DryRun:                    dryRun,
+			LogLevel:                  logLevel,
+			AppName:                   appName,
+			UpdateApps:                updateApps,
+			File:                      path.Join(gitDir, appName, gitFile),
+			GitCredentials:            gitCredentials,
+			GitConf:                   gitConf,
+			AllowErrorNothingToUpdate: allowErrorNothingToUpdate,
 		}
 
-		checkExecutionRunImageUpdater(cfg, logCtx, appName, allowErrorNothingToUpdate)
+		checkExecutionRunImageUpdater(cfg, logCtx, appName)
 	},
 }
 

--- a/internal/app/updater/commit_test.go
+++ b/internal/app/updater/commit_test.go
@@ -623,6 +623,11 @@ func TestUpdateApplication(t *testing.T) {
 		log.Fatal(err)
 	}
 	assert.DeepEqual(t, *apps, changeEntries)
+
+	cfg.AllowErrorNothingToUpdate = false
+	_, err = UpdateApplication(cfg, syncState)
+	expectedErrorMessage := "nothing to update, skipping commit"
+	assert.Error(t, err, expectedErrorMessage)
 }
 
 func getSSHRepoHostnameAndPort() string {

--- a/internal/app/updater/config.go
+++ b/internal/app/updater/config.go
@@ -6,13 +6,14 @@ import (
 
 // HelmUpdaterConfig contains global configuration and required runtime data
 type HelmUpdaterConfig struct {
-	DryRun         bool
-	LogLevel       string
-	AppName        string
-	UpdateApps     []ChangeEntry
-	File           string
-	GitCredentials *git.Credentials
-	GitConf        *git.Conf
+	DryRun                    bool
+	LogLevel                  string
+	AppName                   string
+	UpdateApps                []ChangeEntry
+	File                      string
+	GitCredentials            *git.Credentials
+	GitConf                   *git.Conf
+	AllowErrorNothingToUpdate bool
 }
 
 // ChangeEntry represents values that has been changed by Helm Repo Updater


### PR DESCRIPTION
Added new option ` --allow-nothing-to-update` for allow error `nothing to update, skipping commit` finishing successfully (without `os.Exit(1)`) the execution